### PR TITLE
Add configurable path to lookup tables

### DIFF
--- a/deduce/lookup_structs.py
+++ b/deduce/lookup_structs.py
@@ -10,7 +10,7 @@ from typing import Optional
 import docdeid as dd
 from docdeid.tokenizer import Tokenizer
 
-from deduce.data.lookup.src import all_lists
+
 from deduce.depr import DeprecatedDsCollection
 from deduce.lookup_struct_loader import (
     load_eponymous_disease_lookup,
@@ -203,6 +203,7 @@ def get_lookup_structs(
     lookup_path: Path,
     tokenizer: Tokenizer,
     deduce_version: str,
+    all_lists: list,
     build: bool = False,
     save_cache: bool = True,
 ) -> dd.ds.DsCollection:
@@ -212,6 +213,7 @@ def get_lookup_structs(
         lookup_path: The base path for lookup sets.
         tokenizer: The tokenizer, used to create sequences for LookupTrie
         deduce_version: The current deduce version, used to validate cache.
+        all_lists: The list of lookup tables that must be used.
         build: Whether to do a full build, even when cache is present and valid.
         save_cache: Whether to save to cache. Only used after building.
 


### PR DESCRIPTION
Add key "lookup_table_path" to config.json that points to the directory where 'cache' en 'src' are located.
Path is absolute ('C:/data/base-config.json' , '/data/baseconfig.json') or relative to the location of the base-config.json (up or down the tree e.g. './data/lookup' or '../../configs/version-1')

Also changed the 'all_lists' variable definition which pointed to a fixed location in deduce. 'all_lists' is now also placed in the config file as key "all_lists".

-Does not break previous configuration settings
-Priority order:
1) use values from base-config.json
2) when not found in config.json, use old default behavior 
3) when old version of all_lists AND the one from config.json are '[]', generate all _lists dynamically from directory structure.

base-config.json:
{
  "lookup_table_path": "./data/lookup",
  "all_lists": [
    "institutions/lst_healthcare_institution",
    "institutions/lst_hospital",
    "institutions/lst_hospital_abbr",
    "locations/lst_placename",
    "locations/lst_street",
    "names/lst_first_name",
    "names/lst_initial",
    "names/lst_interfix",
    "names/lst_interfix_surname",
    "names/lst_prefix",
    "names/lst_surname",
    "whitelist/lst_common_word",
    "whitelist/lst_eponymous_disease",
    "whitelist/lst_medical_term",
    "whitelist/lst_stop_word"
  ],
  "adjacent_annotations_slack": "[\\. \\-]?[\\. ]?",
  ...
  [snip]
  ...
  }